### PR TITLE
fix the target directory of external resources for macOS

### DIFF
--- a/src/AppGenerator-OSX/AppGeneratorOSXGenerator.class.st
+++ b/src/AppGenerator-OSX/AppGeneratorOSXGenerator.class.st
@@ -31,7 +31,8 @@ AppGeneratorOSXGenerator >> copyInstallerBackground [
 { #category : 'external resources' }
 AppGeneratorOSXGenerator >> externalResourceTargetDirectory [
 
-	^ outputDirectory / self appName , '.app' / 'Contents' / 'Resources'
+	^ outputDirectory / (self appName , '.app') / 'Contents'
+	  / 'Resources'
 ]
 
 { #category : 'utilities' }
@@ -71,7 +72,7 @@ AppGeneratorOSXGenerator >> generateBuildScript [
 		to: outputDirectory / 'build.sh'
 ]
 
-{ #category : 'as yet unclassified' }
+{ #category : 'generating' }
 AppGeneratorOSXGenerator >> generatePListIn: appDirectory [
 
 	(appDirectory / 'Contents') ensureCreateDirectory.


### PR DESCRIPTION
without this fix, the appGenerator puts external files/directories into $target/Example..app instead of $target/Example.app